### PR TITLE
crash_dump: disallow ptrace of TCB components

### DIFF
--- a/prebuilts/api/26.0/private/crash_dump.te
+++ b/prebuilts/api/26.0/private/crash_dump.te
@@ -1,1 +1,12 @@
 typeattribute crash_dump coredomain;
+
+allow crash_dump {
+  domain
+  -crash_dump
+  -init
+  -kernel
+  -keystore
+  -logd
+  -ueventd
+  -vold
+}:process { ptrace signal sigchld sigstop sigkill };

--- a/prebuilts/api/26.0/public/crash_dump.te
+++ b/prebuilts/api/26.0/public/crash_dump.te
@@ -1,14 +1,6 @@
 type crash_dump, domain;
 type crash_dump_exec, exec_type, file_type;
 
-allow crash_dump {
-  domain
-  -init
-  -crash_dump
-  -keystore
-  -logd
-}:process { ptrace signal sigchld sigstop sigkill };
-
 # crash_dump might inherit CAP_SYS_PTRACE from a privileged process,
 # which will result in an audit log even when it's allowed to trace.
 dontaudit crash_dump self:capability { sys_ptrace };

--- a/private/crash_dump.te
+++ b/private/crash_dump.te
@@ -1,1 +1,12 @@
 typeattribute crash_dump coredomain;
+
+allow crash_dump {
+  domain
+  -crash_dump
+  -init
+  -kernel
+  -keystore
+  -logd
+  -ueventd
+  -vold
+}:process { ptrace signal sigchld sigstop sigkill };

--- a/public/crash_dump.te
+++ b/public/crash_dump.te
@@ -1,14 +1,6 @@
 type crash_dump, domain;
 type crash_dump_exec, exec_type, file_type;
 
-allow crash_dump {
-  domain
-  -init
-  -crash_dump
-  -keystore
-  -logd
-}:process { ptrace signal sigchld sigstop sigkill };
-
 # crash_dump might inherit CAP_SYS_PTRACE from a privileged process,
 # which will result in an audit log even when it's allowed to trace.
 dontaudit crash_dump self:capability { sys_ptrace };


### PR DESCRIPTION
Remove permissions.

Bug: 110107376
Test: kill -6 <components excluded from ptrace>
Change-Id: If8b9c932af03a551e40e786d591544ecdd4e5c98
Merged-In: If8b9c932af03a551e40e786d591544ecdd4e5c98
(cherry picked from commit f1554f1588eab05eca7eb7ccba41d5955a563837)
(cherry picked from commit 573d333589bd1bac02e35f0bd6958758ca65ae9e)